### PR TITLE
feature/improve lumo styles

### DIFF
--- a/theme/lumo/multiselect-combo-box-input-styles.html
+++ b/theme/lumo/multiselect-combo-box-input-styles.html
@@ -8,8 +8,7 @@
     <style include="lumo-field-button">
       :host {
         display: flex;
-        border: 1px solid;
-        border-radius: calc(var(--lumo-border-radius) / 2);
+        border-radius: var(--lumo-border-radius);
         border-color: var(--lumo-contrast-10pct);
         outline: none;
       }
@@ -32,9 +31,9 @@
         display: flex;
         flex: 0 0 25px;
         align-items: center;
-        padding: var(--lumo-space-xs);
+        padding-left: var(--lumo-space-s);
         margin: var(--lumo-space-xs);
-        border-radius: calc(var(--lumo-border-radius) / 2);
+        border-radius: var(--lumo-border-radius);
         background-color: var(--lumo-contrast-20pct);
         cursor: default;
         white-space: nowrap;
@@ -46,7 +45,6 @@
         display: flex;
         align-items: center;
         font-size: var(--lumo-font-size-s);
-        padding-right: var(--lumo-space-xs);
       }
 
       [part="token-remove-button"]::before {

--- a/theme/lumo/multiselect-combo-box-styles.html
+++ b/theme/lumo/multiselect-combo-box-styles.html
@@ -110,7 +110,7 @@
     <template>
       <style>
         :host(.multiselect) [part="input-field"],
-        [part="input-field"]::after {
+        :host(.multiselect) [part="input-field"]::after {
           background-color: transparent;
           font-size: var(--lumo-font-size-s);
         }


### PR DESCRIPTION
This PR improves the default lumo component styling (fixes #8 ):
- ensures the input field has a transparent background
- aligns border styling with other vaadin components
- improves the default token chip styles