### PR TITLE
updated vaadin-combo-box dependency version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0",
-    "vaadin-combo-box": "vaadin/vaadin-combo-box#^4.2.5",
+    "vaadin-combo-box": "vaadin/vaadin-combo-box#^4.2.7",
     "vaadin-text-field": "vaadin/vaadin-text-field#^2.3.4",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.4.4",
     "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.1.3",

--- a/src/multiselect-combo-box.html
+++ b/src/multiselect-combo-box.html
@@ -124,24 +124,12 @@
             /**
              * The `invalid` state error-message.
              */
-            errorMessage: String,
-
-            /**
-             * `true` if overlay is opened.
-             */
-            _opened: Boolean,
-
-            /**
-             * `true` if overlay has been opened at least once.
-             */
-            _openedOnce: Boolean,
+            errorMessage: String
           };
         }
 
         static get observers() {
-          return [
-            '_selectedItemsObserver(selectedItems, selectedItems.*)',
-            '_openedObserver(_opened)'];
+          return ['_selectedItemsObserver(selectedItems, selectedItems.*)'];
         }
 
         /**
@@ -159,16 +147,8 @@
           this.hasValue = selectedItems && selectedItems.length > 0;
           this._setTitle(this._getDisplayValue(selectedItems, this.itemLabelPath));
 
-          // due to: https://github.com/vaadin/vaadin-combo-box/issues/780,
-          // call `render()` only if combo box was opened at least once
-          if (this._openedOnce) {
+          if (this.$.comboBox.render) {
             this.$.comboBox.render();
-          }
-        }
-
-        _openedObserver(opened) {
-          if (!this._openedOnce && opened) {
-            this._openedOnce = true;
           }
         }
 

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -71,6 +71,7 @@
           it('should set `hasValue` to `false` and set empty title when selected items is empty', () => {
             // given
             const selectedItems = [];
+            multiselectComboBox.$.comboBox.render = sinon.stub();
 
             // when
             multiselectComboBox._selectedItemsObserver(selectedItems);
@@ -78,11 +79,13 @@
             // then
             expect(multiselectComboBox.hasValue).to.be.false;
             expect(multiselectComboBox.title).to.be.empty;
+            sinon.assert.calledOnce(multiselectComboBox.$.comboBox.render);
           });
 
           it('should set `hasValue` to `true` and set title', () => {
             // given
             const selectedItems = ['item 1', 'item 2'];
+            multiselectComboBox.$.comboBox.render = sinon.stub();
 
             // when
             multiselectComboBox._selectedItemsObserver(selectedItems);
@@ -90,34 +93,7 @@
             // then
             expect(multiselectComboBox.hasValue).to.be.true;
             expect(multiselectComboBox.title).to.be.eql('item 1, item 2');
-          });
-
-          it('should call render if overlay has been opened at least once', () => {
-            // given
-            const selectedItems = ['item 1', 'item 2'];
-            multiselectComboBox._openedOnce = true; // overlay opened at least once
-
-            multiselectComboBox.$.comboBox.render = sinon.stub();
-
-            // when
-            multiselectComboBox._selectedItemsObserver(selectedItems);
-
-            // then
             sinon.assert.calledOnce(multiselectComboBox.$.comboBox.render);
-          });
-
-          it('should not call render if overlay has not been opened at least once', () => {
-            // given
-            const selectedItems = ['item 1', 'item 2'];
-            multiselectComboBox._openedOnce = false; // overlay has not been opened yet
-
-            multiselectComboBox.$.comboBox.render = sinon.stub();
-
-            // when
-            multiselectComboBox._selectedItemsObserver(selectedItems);
-
-            // then
-            sinon.assert.notCalled(multiselectComboBox.$.comboBox.render);
           });
         });
 
@@ -327,44 +303,6 @@
 
             // then
             expect(result).to.be.eql('item 11, item 22');
-          });
-        });
-
-        describe('_openedObserver', () => {
-          it('should set _openedOnce to true if previously not set and overlay opened', () => {
-            // given
-            multiselectComboBox._openedOnce = false;
-            const opened = true;
-
-            // when
-            multiselectComboBox._openedObserver(opened);
-
-            // then
-            expect(multiselectComboBox._openedOnce).to.be.true;
-          });
-
-          it('should not change _openedOnce value if overlay is not opened', () => {
-            // given
-            multiselectComboBox._openedOnce = false;
-            const opened = false;
-
-            // when
-            multiselectComboBox._openedObserver(opened);
-
-            // then
-            expect(multiselectComboBox._openedOnce).to.be.false;
-          });
-
-          it('should not change _openedOnce if previously set', () => {
-            // given
-            multiselectComboBox._openedOnce = true; // already set
-            const opened = true;
-
-            // when
-            multiselectComboBox._openedObserver(opened);
-
-            // then
-            expect(multiselectComboBox._openedOnce).to.be.true;
           });
         });
 


### PR DESCRIPTION
This PR updates the `vaadin-combo-box` dependency version. This brings various improvements, most notably it contains fixes for: https://github.com/vaadin/vaadin-combo-box/issues/780 and https://github.com/vaadin/vaadin-combo-box/issues/792. With these fixes there is no longer a need to check if the overlay has been opened before calling render, and it also fixes #14 .