### PR TITLE
fixed lumo theme input field error style

### DIFF
--- a/theme/lumo/multiselect-combo-box-styles.html
+++ b/theme/lumo/multiselect-combo-box-styles.html
@@ -56,6 +56,10 @@
         transform-origin: 100% 0;
       }
 
+      :host([invalid]) [part="input-field"] {
+        background-color: var(--lumo-error-color-10pct);
+      }
+
       /* Trigger when not focusing using the keyboard */
       :host([focused]:not([focus-ring]):not([readonly])) [part="input-field"]::after {
         transform: scaleX(0);


### PR DESCRIPTION
This PR updates the multiselect combo box lumo styles to match the vaadin components when in error state and fixes #17 .