### PR TITLE
fixed lumo text field styling issue

### DIFF
--- a/theme/lumo/multiselect-combo-box-styles.html
+++ b/theme/lumo/multiselect-combo-box-styles.html
@@ -121,7 +121,7 @@
       <style>
         :host(.multiselect) [part="input-field"],
         :host(.multiselect) [part="input-field"]::after {
-          background-color: transparent;
+          background-color: transparent !important;
           font-size: var(--lumo-font-size-s);
         }
       </style>


### PR DESCRIPTION
This PR fixes the lumo component style which is broken when the component is in disabled mode:

<img width="800" alt="disabled state issue" src="https://user-images.githubusercontent.com/15094658/57568214-d1bfe100-73ec-11e9-8d65-4377976582cc.png">
