### PR TITLE
feature/compact mode

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,7 @@
 
     <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
     <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
-    <link rel="import" href="../multiselect-combo-box.html">
+    <link rel="import" href="../theme/lumo/multiselect-combo-box.html">
 
     <custom-style>
       <style is="custom-style" include="demo-pages-shared-styles">
@@ -87,6 +87,39 @@
           </script>
         </template>
       </demo-snippet>
+    </div>
+
+    <div class="vertical-section-container centered">
+        <h3>Multiselect-combo-box in compact mode</h3>
+        <demo-snippet>
+          <template>
+
+            <multiselect-combo-box
+              id="compactMode"
+              label="Multiselect field"
+              compact-mode>
+            </multiselect-combo-box>
+
+            <script>
+              window.addEventListener('WebComponentsReady', () => {
+                const compactModeMultiselectComboBox = document.querySelector('#compactMode');
+                compactModeMultiselectComboBox.items = [
+                  'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
+                  'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
+                  'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus',
+                  'Sulfur', 'Chlorine', 'Argon', 'Potassium', 'Calcium',
+                  'Scandium', 'Titanium', 'Vanadium', 'Chromium', 'Manganese',
+                  'Iron', 'Cobalt', 'Nickel', 'Copper', 'Zinc'
+                ];
+                compactModeMultiselectComboBox.selectedItems = [
+                  'Helium',
+                  'Lithium',
+                  'Beryllium'
+                ];
+              });
+            </script>
+          </template>
+        </demo-snippet>
     </div>
 
     <div class="vertical-section-container centered">

--- a/demo/material/index.html
+++ b/demo/material/index.html
@@ -119,6 +119,39 @@
     </div>
 
     <div class="vertical-section-container centered">
+      <h3>Multiselect-combo-box in compact mode</h3>
+      <demo-snippet>
+        <template>
+
+          <multiselect-combo-box
+            id="compactMode"
+            label="Multiselect field"
+            compact-mode>
+          </multiselect-combo-box>
+
+          <script>
+            window.addEventListener('WebComponentsReady', () => {
+              const compactModeMultiselectComboBox = document.querySelector('#compactMode');
+              compactModeMultiselectComboBox.items = [
+                'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
+                'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
+                'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus',
+                'Sulfur', 'Chlorine', 'Argon', 'Potassium', 'Calcium',
+                'Scandium', 'Titanium', 'Vanadium', 'Chromium', 'Manganese',
+                'Iron', 'Cobalt', 'Nickel', 'Copper', 'Zinc'
+              ];
+              compactModeMultiselectComboBox.selectedItems = [
+                'Helium',
+                'Lithium',
+                'Beryllium'
+              ];
+            });
+          </script>
+        </template>
+      </demo-snippet>
+    </div>
+
+    <div class="vertical-section-container centered">
       <h3>Required multiselect-combo-box</h3>
       <demo-snippet>
         <template>

--- a/src/multiselect-combo-box-input.html
+++ b/src/multiselect-combo-box-input.html
@@ -7,11 +7,17 @@
 <dom-module id="multiselect-combo-box-input">
   <template>
     <div id="tokens" part="tokens" slot="prefix">
-      <template is="dom-repeat" items="[[items]]">
-        <div part="token">
-          <div part="token-label">[[_getItemDisplayValue(item, itemLabelPath)]]</div>
-          <div part="token-remove-button" title="remove" role="button" on-click="_removeToken"></div>
-        </div>
+      <template is="dom-if" if="[[compactMode]]" restamp>
+        <div part="compact-mode-label">[[_getCompactModeDisplayValue(items, items.*)]]</div>
+      </template>
+
+      <template is="dom-if" if="[[!compactMode]]" restamp>
+        <template is="dom-repeat" items="[[items]]">
+          <div part="token">
+            <div part="token-label">[[_getItemDisplayValue(item, itemLabelPath)]]</div>
+            <div part="token-remove-button" title="remove" role="button" on-click="_removeToken"></div>
+          </div>
+        </template>
       </template>
 
       <vaadin-text-field
@@ -23,6 +29,7 @@
         on-keydown="_onKeyDown"
         multiselect-has-value$="[[hasValue]]"
         multiselect-has-label$="[[hasLabel]]"
+        compact-mode$="[[compactMode]]"
         theme$="[[theme]]"
         disabled="[[disabled]]">
 
@@ -89,6 +96,10 @@
             composed: true,
             bubbles: true
           }));
+        }
+
+        _resolvePlaceholder(compactMode, placeholder) {
+          return compactMode ? '' : placeholder;
         }
       }
 

--- a/src/multiselect-combo-box-mixin.html
+++ b/src/multiselect-combo-box-mixin.html
@@ -39,6 +39,16 @@
         },
 
         /**
+         * This attribute indicates that the component is rendered in 'compact mode'.
+         * In this mode, the component displays the number of items currently selected.
+         */
+        compactMode: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true
+        },
+
+        /**
          * The item property to be used as the `label` in combo-box.
          */
         itemLabelPath: String,
@@ -78,6 +88,14 @@
      */
     _getItemDisplayValue(item, itemLabelPath) {
       return item && item.hasOwnProperty(itemLabelPath) ? item[itemLabelPath] : item;
+    }
+
+    /**
+     * Retrieves the component display value when in compact mode.
+     */
+    _getCompactModeDisplayValue(items) {
+      const suffix = (items.length === 0 || items.length > 1) ? 'values' : 'value';
+      return `${items.length} ${suffix}`;
     }
   };
 }

--- a/src/multiselect-combo-box.html
+++ b/src/multiselect-combo-box.html
@@ -10,7 +10,7 @@
     <label part="label">[[label]]</label>
 
     <div part="readonly-container" hidden$="[[!readonly]]">
-      [[_getDisplayValue(selectedItems, itemLabelPath)]]
+      [[_getReadonlyValue(selectedItems, itemLabelPath, compactMode)]]
     </div>
 
     <vaadin-combo-box-light
@@ -32,6 +32,7 @@
         placeholder="[[placeholder]]"
         item-label-path="[[itemLabelPath]]"
         items="[[selectedItems]]"
+        compact-mode="[[compactMode]]"
         on-item-removed="_handleItemRemoved"
         on-remove-all-items="_handleRemoveAllItems"
         has-value="[[hasValue]]"
@@ -216,6 +217,12 @@
         _handleRemoveAllItems() {
           this.set('selectedItems', []);
           this.validate();
+        }
+
+        _getReadonlyValue(selectedItems, itemLabelPath, compactMode) {
+          return compactMode ?
+            this._getCompactModeDisplayValue(selectedItems) :
+            this._getDisplayValue(selectedItems, itemLabelPath);
         }
 
         _getDisplayValue(selectedItems, itemLabelPath) {

--- a/test/multiselect-combo-box-input_test.html
+++ b/test/multiselect-combo-box-input_test.html
@@ -164,6 +164,32 @@
           });
         });
 
+        describe('_resolvePlaceholder', () => {
+          it('should resolve placeholder when not in compact mode', () => {
+            // given
+            const compactMode = false;
+            const placeholder = 'placeholder text';
+
+            // when
+            const result = multiselectComboBoxInput._resolvePlaceholder(compactMode, placeholder);
+
+            // then
+            expect(result).to.be.eql(placeholder);
+          });
+
+          it('should resolve to empty string when in compact mode', () => {
+            // given
+            const compactMode = true;
+            const placeholder = 'placeholder text';
+
+            // when
+            const result = multiselectComboBoxInput._resolvePlaceholder(compactMode, placeholder);
+
+            // then
+            expect(result).to.be.eql('');
+          });
+        });
+
       });
     </script>
 

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -443,6 +443,151 @@
             expect(multiselectComboBox.hasAttribute('has-label')).to.be.false;
           });
         });
+
+        describe('_getReadonlyValue', () => {
+          it('should get display value when not in compact mode', () => {
+            // given
+            const compactMode = false;
+            const selectedItems = ['item 1', 'item 2'];
+            const itemLabelPath = undefined;
+
+            // when
+            const result = multiselectComboBox._getReadonlyValue(selectedItems, itemLabelPath, compactMode);
+
+            // then
+            expect(result).to.be.eql('item 1, item 2');
+          });
+
+          it('should get display value of object items when not in compact mode', () => {
+            // given
+            const compactMode = false;
+            const selectedItems = [{label: 'item 1 label'}, {label: 'item 2 label'}];
+            const itemLabelPath = 'label';
+
+            // when
+            const result = multiselectComboBox._getReadonlyValue(selectedItems, itemLabelPath, compactMode);
+
+            // then
+            expect(result).to.be.eql('item 1 label, item 2 label');
+          });
+
+          it('should get number of selected items when in compact mode and list is empty', () => {
+            // given
+            const compactMode = true;
+            const selectedItems = [];
+            const itemLabelPath = undefined;
+
+            // when
+            const result = multiselectComboBox._getReadonlyValue(selectedItems, itemLabelPath, compactMode);
+
+            // then
+            expect(result).to.be.eql('0 values');
+          });
+
+          it('should get number of selected items when in compact mode and list contains one item', () => {
+            // given
+            const compactMode = true;
+            const selectedItems = ['item 1'];
+            const itemLabelPath = undefined;
+
+            // when
+            const result = multiselectComboBox._getReadonlyValue(selectedItems, itemLabelPath, compactMode);
+
+            // then
+            expect(result).to.be.eql('1 value');
+          });
+
+          it('should get number of selected items when in compact mode and list contains at least two items', () => {
+            // given
+            const compactMode = true;
+            const selectedItems = ['item 1', 'item 2'];
+            const itemLabelPath = undefined;
+
+            // when
+            const result = multiselectComboBox._getReadonlyValue(selectedItems, itemLabelPath, compactMode);
+
+            // then
+            expect(result).to.be.eql('2 values');
+          });
+        });
+
+        describe('_getItemDisplayValue', () => {
+          it('should return item when not an object', () => {
+            // given
+            const item = 'multiselect-combo-box';
+
+            // when
+            const result = multiselectComboBox._getItemDisplayValue(item);
+
+            // then
+            expect(result).to.be.eql(item);
+          });
+
+          it('should return item when object does not have the specified property', () => {
+            // given
+            const item = {
+              key1: 'multiselect-combo-box',
+              key2: 'select more than one value'
+            };
+            const itemLabelPath = 'foo';
+
+            // when
+            const result = multiselectComboBox._getItemDisplayValue(item, itemLabelPath);
+
+            // then
+            expect(result).to.be.eql(item);
+          });
+
+          it('should return item property', () => {
+            // given
+            const item = {
+              key1: 'multiselect-combo-box',
+              key2: 'select more than one value'
+            };
+            const itemLabelPath = 'key1';
+
+            // when
+            const result = multiselectComboBox._getItemDisplayValue(item, itemLabelPath);
+
+            // then
+            expect(result).to.be.eql(item.key1);
+          });
+        });
+
+        describe('_getCompactModeDisplayValue', () => {
+          it('should return display label for empty items list', () => {
+            // given
+            const items = [];
+
+            // when
+            const result = multiselectComboBox._getCompactModeDisplayValue(items);
+
+            // then
+            expect(result).to.be.eql('0 values');
+          });
+
+          it('should return display label for a single value in the items list', () => {
+            // given
+            const items = ['one item'];
+
+            // when
+            const result = multiselectComboBox._getCompactModeDisplayValue(items);
+
+            // then
+            expect(result).to.be.eql('1 value');
+          });
+
+          it('should return display label for a multiple values in the items list', () => {
+            // given
+            const items = ['one item', 'another item', 'yet another item'];
+
+            // when
+            const result = multiselectComboBox._getCompactModeDisplayValue(items);
+
+            // then
+            expect(result).to.be.eql('3 values');
+          });
+        });
       });
     </script>
 

--- a/theme/lumo/multiselect-combo-box-input-styles.html
+++ b/theme/lumo/multiselect-combo-box-input-styles.html
@@ -13,8 +13,8 @@
         outline: none;
       }
 
-      :host([disabled ]) [part="token-label"],
-      :host([disabled ]) [part="token-remove-button"],
+      :host([disabled]) [part="token-label"],
+      :host([disabled]) [part="token-remove-button"],
       :host([disabled]) [part="compact-mode-label"] {
         color: var(--lumo-disabled-text-color);
         -webkit-text-fill-color: var(--lumo-disabled-text-color);

--- a/theme/lumo/multiselect-combo-box-input-styles.html
+++ b/theme/lumo/multiselect-combo-box-input-styles.html
@@ -14,7 +14,8 @@
       }
 
       :host([disabled ]) [part="token-label"],
-      :host([disabled ]) [part="token-remove-button"]{
+      :host([disabled ]) [part="token-remove-button"],
+      :host([disabled]) [part="compact-mode-label"] {
         color: var(--lumo-disabled-text-color);
         -webkit-text-fill-color: var(--lumo-disabled-text-color);
         pointer-events: none;
@@ -24,6 +25,15 @@
         flex: 1 1;
         min-width: 80px;
         padding: 0;
+      }
+
+      [part="compact-mode-label"] {
+        display: flex;
+        flex-grow: 1;
+        align-items: center;
+        margin: var(--lumo-space-s);
+        color: var(--lumo-contrast-70pct);
+        cursor: default;
       }
 
       [part="tokens"] {

--- a/theme/lumo/multiselect-combo-box-styles.html
+++ b/theme/lumo/multiselect-combo-box-styles.html
@@ -124,6 +124,18 @@
           background-color: transparent !important;
           font-size: var(--lumo-font-size-s);
         }
+
+        :host(.multiselect[compact-mode]) [part="input-field"] {
+          cursor: default;
+        }
+
+        :host(.multiselect[compact-mode]) [part="input-field"]::after {
+          border: none;
+        }
+
+        :host(.multiselect[compact-mode]) [part="input-field"] [part="value"] {
+          visibility: hidden;
+        }
       </style>
     </template>
   </dom-module>

--- a/theme/material/multiselect-combo-box-input-styles.html
+++ b/theme/material/multiselect-combo-box-input-styles.html
@@ -47,11 +47,13 @@
       }
 
       :host([disabled]) [part="token-label"],
-      :host([disabled]) [part="token-remove-button"] {
+      :host([disabled]) [part="token-remove-button"],
+      :host([disabled]) [part="compact-mode-label"] {
         pointer-events: none;
       }
 
-      :host([disabled]) [part="token-label"] {
+      :host([disabled]) [part="token-label"],
+      :host([disabled]) [part="compact-mode-label"] {
         color: var(--material-disabled-text-color);
         -webkit-text-fill-color: var(--material-disabled-text-color);
       }
@@ -66,6 +68,14 @@
         min-width: 80px;
         padding: 0;
         margin-bottom: 4px;
+      }
+
+      [part="compact-mode-label"] {
+        display: flex;
+        flex-grow: 1;
+        align-items: center;
+        margin: var(--material-space-s);
+        cursor: default;
       }
 
       [part="tokens"] {

--- a/theme/material/multiselect-combo-box-styles.html
+++ b/theme/material/multiselect-combo-box-styles.html
@@ -41,7 +41,7 @@
         background-color: var(--material-error-color);
       }
 
-      :host([has-label]:not([has-value]):not([focused]):not([invalid]):not([theme="always-float-label"]):not([disabled])) [part="label"] {
+      :host([has-label]:not([has-value]):not([focused]):not([invalid]):not([theme="always-float-label"]):not([compact-mode]):not([disabled])) [part="label"] {
         transform: scale(1) translateY(24px);
         transition-timing-function: ease, ease, step-start;
         pointer-events: none;
@@ -134,6 +134,14 @@
 
         :host(.multiselect) [part="input-field"]::before {
           display: none;
+        }
+
+        :host(.multiselect[compact-mode]) [part="input-field"] {
+          cursor: default;
+        }
+
+        :host(.multiselect[compact-mode]) [part="input-field"] [part="value"] {
+          visibility: hidden;
         }
 
         /* placeholder styles */


### PR DESCRIPTION
This PR introduces the `compact mode` of the `multiselect-combo-box`. In this mode of operation the component displays the number of selected items (instead of individual tokens):

![compact-mode](https://user-images.githubusercontent.com/15094658/57573468-8c250780-7430-11e9-9fb8-810f3be07c89.gif)