### PR TITLE
compatibility with vaadin-crud

### DIFF
--- a/src/multiselect-combo-box.html
+++ b/src/multiselect-combo-box.html
@@ -244,6 +244,10 @@
           this.$.comboBox.render && this.$.comboBox.render();
         }
 
+        _dispatchChangeEvent() {
+          this.dispatchEvent(new CustomEvent('change', {bubbles: true}));
+        }
+
         _comboBoxValueChanged() {
           const item = this.$.comboBox.selectedItem;
 
@@ -260,7 +264,9 @@
           this.selectedItems = update;
 
           this.$.comboBox.value = '';
-          this.validate();
+          if (this.validate()) {
+            this._dispatchChangeEvent();
+          }
         }
 
         _isSelected(item, selectedItems, itemIdPath) {
@@ -285,12 +291,16 @@
           const update = this.selectedItems.slice(0);
           update.splice(update.indexOf(item), 1);
           this.selectedItems = update;
-          this.validate();
+          if (this.validate()) {
+            this._dispatchChangeEvent();
+          }
         }
 
         _handleRemoveAllItems() {
           this.set('selectedItems', []);
-          this.validate();
+          if (this.validate()) {
+            this._dispatchChangeEvent();
+          }
         }
 
         _getReadonlyValue(selectedItems, itemLabelPath, compactMode) {

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -154,6 +154,17 @@
           });
         });
 
+        describe('_dispatchChangeEvent', () => {
+          it('should call dispatchEvent', () => {
+            // given
+            multiselectComboBox.dispatchEvent = sinon.stub();
+            // when
+            multiselectComboBox._dispatchChangeEvent();
+            // then
+            sinon.assert.calledOnce(multiselectComboBox.dispatchEvent);
+          });
+        });
+
         describe('_comboBoxValueChanged', () => {
           it('should add item to selected items if not previously selected', () => {
             // given
@@ -161,6 +172,8 @@
             multiselectComboBox.$.comboBox.selectedItem = 'item 3';
 
             multiselectComboBox.validate = sinon.stub();
+            multiselectComboBox.validate.returns(true);
+            multiselectComboBox._dispatchChangeEvent = sinon.stub();
 
             // when
             multiselectComboBox._comboBoxValueChanged();
@@ -171,6 +184,7 @@
             expect(multiselectComboBox.selectedItems).to.include('item 3');
             expect(multiselectComboBox.$.comboBox.value).to.be.empty;
             sinon.assert.calledOnce(multiselectComboBox.validate);
+            sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
           });
 
           it('should remove item from selected items if previously selected', () => {
@@ -179,6 +193,8 @@
             multiselectComboBox.$.comboBox.selectedItem = 'item 2';
 
             multiselectComboBox.validate = sinon.stub();
+            multiselectComboBox.validate.returns(true);
+            multiselectComboBox._dispatchChangeEvent = sinon.stub();
 
             // when
             multiselectComboBox._comboBoxValueChanged();
@@ -189,6 +205,7 @@
             expect(multiselectComboBox.selectedItems).to.not.include('item 2');
             expect(multiselectComboBox.$.comboBox.value).to.be.empty;
             sinon.assert.calledOnce(multiselectComboBox.validate);
+            sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
           });
 
           it('should add object item to selected items if not previously selected', () => {
@@ -201,6 +218,8 @@
             multiselectComboBox.$.comboBox.selectedItem = {id: 3, label: 'item 3'};
 
             multiselectComboBox.validate = sinon.stub();
+            multiselectComboBox.validate.returns(true);
+            multiselectComboBox._dispatchChangeEvent = sinon.stub();
 
             // when
             multiselectComboBox._comboBoxValueChanged();
@@ -211,6 +230,7 @@
             expect(multiselectComboBox.selectedItems).to.include({id: 3, label: 'item 3'});
             expect(multiselectComboBox.$.comboBox.value).to.be.empty;
             sinon.assert.calledOnce(multiselectComboBox.validate);
+            sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
           });
 
           it('should remove object item from selected items if previously selected', () => {
@@ -224,6 +244,9 @@
             multiselectComboBox.$.comboBox.selectedItem = {id: 2, label: 'item 2'};
 
             multiselectComboBox.validate = sinon.stub();
+            multiselectComboBox.validate.returns(true);
+
+            multiselectComboBox._dispatchChangeEvent = sinon.stub();
 
             // when
             multiselectComboBox._comboBoxValueChanged();
@@ -235,6 +258,20 @@
             expect(multiselectComboBox.selectedItems).to.not.include({id: 2, label: 'item 2'});
             expect(multiselectComboBox.$.comboBox.value).to.be.empty;
             sinon.assert.calledOnce(multiselectComboBox.validate);
+            sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
+          });
+
+          it('should not dispath event if validate returns false', () => {
+            // given
+            multiselectComboBox.validate = sinon.stub();
+            multiselectComboBox.validate.returns(false);
+            multiselectComboBox._dispatchChangeEvent = sinon.stub();
+
+            // when
+            multiselectComboBox._comboBoxValueChanged();
+
+            // then
+            sinon.assert.notCalled(multiselectComboBox._dispatchChangeEvent);
           });
         });
 
@@ -306,6 +343,8 @@
             };
             multiselectComboBox.selectedItems = ['item 1', 'item 2', 'item 3'];
             multiselectComboBox.validate = sinon.stub();
+            multiselectComboBox.validate.returns(true);
+            multiselectComboBox._dispatchChangeEvent = sinon.stub();
 
             // when
             multiselectComboBox._handleItemRemoved(event);
@@ -315,6 +354,26 @@
             expect(multiselectComboBox.selectedItems).to.include('item 1');
             expect(multiselectComboBox.selectedItems).to.include('item 3');
             sinon.assert.calledOnce(multiselectComboBox.validate);
+            sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
+          });
+
+
+          it('should not dispath event if validate returns false', () => {
+            // given
+            const event = {
+              detail: {
+                item: 'item 2'
+              }
+            };
+            multiselectComboBox.validate = sinon.stub();
+            multiselectComboBox.validate.returns(false);
+            multiselectComboBox._dispatchChangeEvent = sinon.stub();
+
+            // when
+            multiselectComboBox._handleItemRemoved(event);
+
+            // then
+            sinon.assert.notCalled(multiselectComboBox._dispatchChangeEvent);
           });
         });
 
@@ -323,6 +382,8 @@
             // given
             multiselectComboBox.selectedItems = ['item 1', 'item 2', 'item 3'];
             multiselectComboBox.validate = sinon.stub();
+            multiselectComboBox.validate.returns(true);
+            multiselectComboBox._dispatchChangeEvent = sinon.stub();
 
             // when
             multiselectComboBox._handleRemoveAllItems();
@@ -330,6 +391,20 @@
             // then
             expect(multiselectComboBox.selectedItems).to.be.empty;
             sinon.assert.calledOnce(multiselectComboBox.validate);
+            sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
+          });
+
+          it('should not dispath event if validate returns false', () => {
+            // given
+            multiselectComboBox.validate = sinon.stub();
+            multiselectComboBox.validate.returns(false);
+            multiselectComboBox._dispatchChangeEvent = sinon.stub();
+
+            // when
+            multiselectComboBox._handleRemoveAllItems();
+
+            // then
+            sinon.assert.notCalled(multiselectComboBox._dispatchChangeEvent);
           });
         });
 


### PR DESCRIPTION
This PR adds the same functionality to the Polymer 2.x `multiselect-combo-box` that was introduced by #32