### PR TITLE
Enable `multiselect-combo-box` to support lazy data loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/gatanaso/multiselect-combo-box"
   },
   "name": "multiselect-combo-box",
-  "version": "2.0.3-alpha.2",
+  "version": "2.0.3-alpha.3",
   "main": "multiselect-combo-box.js",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/gatanaso/multiselect-combo-box"
   },
   "name": "multiselect-combo-box",
-  "version": "2.0.2",
+  "version": "2.0.3-alpha",
   "main": "multiselect-combo-box.js",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/gatanaso/multiselect-combo-box"
   },
   "name": "multiselect-combo-box",
-  "version": "2.0.3-alpha",
+  "version": "2.0.3-alpha.1",
   "main": "multiselect-combo-box.js",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/gatanaso/multiselect-combo-box"
   },
   "name": "multiselect-combo-box",
-  "version": "2.0.3-alpha.3",
+  "version": "2.0.3",
   "main": "multiselect-combo-box.js",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/gatanaso/multiselect-combo-box"
   },
   "name": "multiselect-combo-box",
-  "version": "2.0.3-alpha.1",
+  "version": "2.0.3-alpha.2",
   "main": "multiselect-combo-box.js",
   "directories": {
     "test": "test"

--- a/src/multiselect-combo-box-mixin.js
+++ b/src/multiselect-combo-box-mixin.js
@@ -8,10 +8,7 @@ export const MultiselectComboBoxMixin = (base) => class extends base {
       /**
        * The list of items.
        */
-      items: {
-        type: Array,
-        value: () => []
-      },
+      items: Array,
 
       /**
        * The input placeholder.

--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -272,7 +272,20 @@ import './multiselect-combo-box-input.js';
 
       this.selectedItems = update;
 
-      this.$.comboBox.value = '';
+      if (this.$.comboBox.dataProvider && typeof this.$.comboBox.dataProvider === 'function') {
+        // When using a data provider we need to store the value of the `_focusedIndex`
+        // in order to retain the overlay scroll position after the value is reset
+        // (reseting the value sets the `_focusedIndex` to -1).
+        // This ensures that on consecutive value selections, the overlay is opened
+        // at the correct position in the list of items
+        const focusedIndex = this.$.comboBox.filteredItems.indexOf(item);
+        this.$.comboBox.value = null;
+        this.$.comboBox._focusedIndex = focusedIndex;
+      } else {
+        // reset value
+        this.$.comboBox.value = '';
+      }
+
       if (this.validate()) {
         this._dispatchChangeEvent();
       }

--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -89,6 +89,7 @@ import './multiselect-combo-box-input.js';
             id="comboBox"
             part="combo-box"
             hidden\$="[[readonly]]"
+            items="[[items]]"
             item-id-path="[[itemIdPath]]"
             item-label-path="[[itemLabelPath]]"
             item-value-path="[[itemValuePath]]"
@@ -226,10 +227,7 @@ import './multiselect-combo-box-input.js';
     }
 
     static get observers() {
-      return [
-        '_selectedItemsObserver(selectedItems, selectedItems.*)',
-        '_itemsObserver(items, items.*)'
-      ];
+      return ['_selectedItemsObserver(selectedItems, selectedItems.*)'];
     }
 
     /**
@@ -253,10 +251,6 @@ import './multiselect-combo-box-input.js';
       this._setTitle(this._getDisplayValue(selectedItems, this.itemLabelPath));
 
       this.$.comboBox.render && this.$.comboBox.render();
-    }
-
-    _itemsObserver(items) {
-      this.$.comboBox.items = items;
     }
 
     _dispatchChangeEvent() {

--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -320,6 +320,7 @@ import './multiselect-combo-box-input.js';
 
     _handleRemoveAllItems() {
       this.set('selectedItems', []);
+      this.$.comboBox._focusedIndex = -1; // reset focused index
       if (this.validate()) {
         this._dispatchChangeEvent();
       }

--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -89,12 +89,12 @@ import './multiselect-combo-box-input.js';
             id="comboBox"
             part="combo-box"
             hidden\$="[[readonly]]"
-            items="[[items]]"
             item-id-path="[[itemIdPath]]"
             item-label-path="[[itemLabelPath]]"
             item-value-path="[[itemValuePath]]"
             on-change="_comboBoxValueChanged"
-            disabled="[[disabled]]">
+            disabled="[[disabled]]"
+            pageSize="[[pageSize]]">
 
             <multiselect-combo-box-input
               id="input"
@@ -182,6 +182,15 @@ import './multiselect-combo-box-input.js';
         },
 
         /**
+         * Number of items fetched at a time from the dataprovider. This property is delegated to the underlying `vaadin-combo-box`.
+         */
+        pageSize: {
+          type: Number,
+          value: 50,
+          observer: '_pageSizeObserver'
+        },
+
+        /**
          * The `readonly` attribute.
          */
         readonly: {
@@ -217,7 +226,10 @@ import './multiselect-combo-box-input.js';
     }
 
     static get observers() {
-      return ['_selectedItemsObserver(selectedItems, selectedItems.*)'];
+      return [
+        '_selectedItemsObserver(selectedItems, selectedItems.*)',
+        '_itemsObserver(items, items.*)'
+      ];
     }
 
     /**
@@ -241,6 +253,10 @@ import './multiselect-combo-box-input.js';
       this._setTitle(this._getDisplayValue(selectedItems, this.itemLabelPath));
 
       this.$.comboBox.render && this.$.comboBox.render();
+    }
+
+    _itemsObserver(items) {
+      this.$.comboBox.items = items;
     }
 
     _dispatchChangeEvent() {
@@ -376,6 +392,14 @@ import './multiselect-combo-box-input.js';
         const item2Str = this._getItemDisplayValue(item2, this.itemLabelPath);
         return item1Str.localeCompare(item2Str);
       });
+    }
+
+    _pageSizeObserver(pageSize, oldPageSize) {
+      if (Math.floor(pageSize) !== pageSize || pageSize <= 0) {
+        this.pageSize = oldPageSize;
+        throw new Error('`pageSize` value must be an integer > 0');
+      }
+      this.$.comboBox.pageSize = pageSize;
     }
   }
 

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -275,6 +275,37 @@
           // then
           sinon.assert.notCalled(multiselectComboBox._dispatchChangeEvent);
         });
+
+        it('should save focused index when using lazy-loading', () => {
+          // given
+          multiselectComboBox.selectedItems = ['item 1'];
+          multiselectComboBox.$.comboBox.selectedItem = 'item 2';
+          multiselectComboBox.$.comboBox.filteredItems = ['item 1', 'item 2', 'item 3'];
+
+          multiselectComboBox.validate = sinon.stub();
+          multiselectComboBox.validate.returns(true);
+          multiselectComboBox._dispatchChangeEvent = sinon.stub();
+
+          multiselectComboBox.$.comboBox.dataProvider = function dummy() {};
+
+          // when
+          multiselectComboBox._comboBoxValueChanged();
+
+          // then
+          expect(multiselectComboBox.selectedItems).to.have.lengthOf(2);
+          expect(multiselectComboBox.selectedItems).to.include('item 1');
+          expect(multiselectComboBox.selectedItems).to.include('item 2');
+
+          // _focusedIndex was preserved
+          expect(multiselectComboBox.$.comboBox._focusedIndex).to.be.eq(1);
+
+          // value is empty and not `null`, due to `_selectedItemChanged` being called:
+          // https://github.com/vaadin/vaadin-combo-box/blob/81fea466a613a618aa32315dd75cf20e2ff3ea43/src/vaadin-combo-box-mixin.html#L706
+          expect(multiselectComboBox.$.comboBox.value).to.be.empty;
+
+          sinon.assert.calledOnce(multiselectComboBox.validate);
+          sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
+        });
       });
 
       describe('_isSelected', () => {

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -154,21 +154,6 @@
         });
       });
 
-      describe('_itemsObserver', () => {
-        it('should set list of items to the combo box', () => {
-          // given
-          const items = ['item 1', 'item 2'];
-
-          // when
-          multiselectComboBox._itemsObserver(items);
-
-          // then
-          expect(multiselectComboBox.$.comboBox.items).to.have.lengthOf(2);
-          expect(multiselectComboBox.$.comboBox.items).to.include('item 1');
-          expect(multiselectComboBox.$.comboBox.items).to.include('item 2');
-        });
-      });
-
       describe('_dispatchChangeEvent', () => {
         it('should call dispatchEvent', () => {
           // given

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -154,6 +154,21 @@
         });
       });
 
+      describe('_itemsObserver', () => {
+        it('should set list of items to the combo box', () => {
+          // given
+          const items = ['item 1', 'item 2'];
+
+          // when
+          multiselectComboBox._itemsObserver(items);
+
+          // then
+          expect(multiselectComboBox.$.comboBox.items).to.have.lengthOf(2);
+          expect(multiselectComboBox.$.comboBox.items).to.include('item 1');
+          expect(multiselectComboBox.$.comboBox.items).to.include('item 2');
+        });
+      });
+
       describe('_dispatchChangeEvent', () => {
         it('should call dispatchEvent', () => {
           // given
@@ -753,6 +768,68 @@
           expect(selectedItems[0]).to.be.eql({key: 1, label: 'item 1'});
           expect(selectedItems[1]).to.be.eql({key: 2, label: 'item 2'});
           expect(selectedItems[2]).to.be.eql({key: 3, label: 'item 3'});
+        });
+      });
+
+      describe('_pageSizeObserver', () => {
+        it('should throw error when page size is zero', (done) => {
+          // given
+          const pageSize = 0;
+          const oldPageSize = 10;
+
+          try {
+            // when
+            multiselectComboBox._pageSizeObserver(pageSize, oldPageSize);
+          } catch (error) {
+            // then
+            expect(error.message).to.be.eq('`pageSize` value must be an integer > 0');
+            expect(multiselectComboBox.pageSize).to.be.eq(oldPageSize);
+            done();
+          }
+        });
+
+        it('should throw error when page size is decimal', (done) => {
+          // given
+          const pageSize = 3.5;
+          const oldPageSize = 10;
+
+          try {
+            // when
+            multiselectComboBox._pageSizeObserver(pageSize, oldPageSize);
+          } catch (error) {
+            // then
+            expect(error.message).to.be.eq('`pageSize` value must be an integer > 0');
+            expect(multiselectComboBox.pageSize).to.be.eq(oldPageSize);
+            done();
+          }
+        });
+
+        it('should throw error when page size is negative', (done) => {
+          // given
+          const pageSize = -1;
+          const oldPageSize = 10;
+
+          try {
+            // when
+            multiselectComboBox._pageSizeObserver(pageSize, oldPageSize);
+          } catch (error) {
+            // then
+            expect(error.message).to.be.eq('`pageSize` value must be an integer > 0');
+            expect(multiselectComboBox.pageSize).to.be.eq(oldPageSize);
+            done();
+          }
+        });
+
+        it('should set new page size', () => {
+          // given
+          const pageSize = 5;
+
+          // when
+          multiselectComboBox.set('pageSize', pageSize);
+
+          // then
+          expect(multiselectComboBox.pageSize).to.be.eq(pageSize);
+          expect(multiselectComboBox.$.comboBox.pageSize).to.be.eq(pageSize);
         });
       });
     });

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -424,6 +424,7 @@
           expect(multiselectComboBox.selectedItems).to.be.empty;
           sinon.assert.calledOnce(multiselectComboBox.validate);
           sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
+          expect(multiselectComboBox.$.comboBox._focusedIndex).to.be.eq(-1);
         });
 
         it('should not dispath event if validate returns false', () => {
@@ -437,6 +438,7 @@
 
           // then
           sinon.assert.notCalled(multiselectComboBox._dispatchChangeEvent);
+          expect(multiselectComboBox.$.comboBox._focusedIndex).to.be.eq(-1);
         });
       });
 


### PR DESCRIPTION
Adapted `multiselect-combo-box` to better support lazy data loading in the Vaadin wrapper. This PR introduces minor updates to the web component that enable the adding lazy loading support for the [MultiselectComboBox](https://github.com/gatanaso/multiselect-combo-box-flow)