### PR TITLE
introduced the `clear-button-visible` attribute

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -258,5 +258,38 @@
         </template>
       </demo-snippet>
     </div>
+
+    <div class="vertical-section-container centered">
+      <h3>Multiselect-combo-box with `clear-button-visible`</h3>
+      <demo-snippet>
+        <template>
+
+          <multiselect-combo-box
+            id="clearButtonVisibleDemo"
+            label="Multiselect field with clear-button-visible"
+            placeholder="Add"
+            clear-button-visible>
+          </multiselect-combo-box>
+
+          <script>
+            window.addEventListener('WebComponentsReady', function() {
+              const basicMultiselectComboBox = document.querySelector('#clearButtonVisibleDemo');
+              basicMultiselectComboBox.items = [
+                'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
+                'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
+                'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus',
+                'Sulfur', 'Chlorine', 'Argon', 'Potassium', 'Calcium',
+                'Scandium', 'Titanium', 'Vanadium', 'Chromium', 'Manganese',
+                'Iron', 'Cobalt', 'Nickel', 'Copper', 'Zinc'
+              ];
+              basicMultiselectComboBox.selectedItems = [
+                'Helium',
+                'Lithium'
+              ];
+            });
+          </script>
+        </template>
+      </demo-snippet>
+    </div>
   </body>
 </html>

--- a/demo/material/index.html
+++ b/demo/material/index.html
@@ -288,5 +288,38 @@
         </template>
       </demo-snippet>
     </div>
+
+    <div class="vertical-section-container centered">
+      <h3>Multiselect-combo-box with `clear-button-visible`</h3>
+      <demo-snippet>
+        <template>
+
+          <multiselect-combo-box
+            id="clearButtonVisibleDemo"
+            label="Multiselect field with clear-button-visible"
+            placeholder="Add"
+            clear-button-visible>
+          </multiselect-combo-box>
+
+          <script>
+            window.addEventListener('WebComponentsReady', function() {
+              const basicMultiselectComboBox = document.querySelector('#clearButtonVisibleDemo');
+              basicMultiselectComboBox.items = [
+                'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
+                'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
+                'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus',
+                'Sulfur', 'Chlorine', 'Argon', 'Potassium', 'Calcium',
+                'Scandium', 'Titanium', 'Vanadium', 'Chromium', 'Manganese',
+                'Iron', 'Cobalt', 'Nickel', 'Copper', 'Zinc'
+              ];
+              basicMultiselectComboBox.selectedItems = [
+                'Helium',
+                'Lithium'
+              ];
+            });
+          </script>
+        </template>
+      </demo-snippet>
+    </div>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/gatanaso/multiselect-combo-box"
   },
   "name": "multiselect-combo-box",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "main": "multiselect-combo-box.js",
   "directories": {
     "test": "test"

--- a/src/multiselect-combo-box-input.js
+++ b/src/multiselect-combo-box-input.js
@@ -48,7 +48,15 @@ import {MultiselectComboBoxMixin} from './multiselect-combo-box-mixin.js';
             theme\$="[[theme]]"
             disabled="[[disabled]]">
 
-            <div id="clearButton" part="clear-button" slot="suffix" role="button" on-click="_removeAll"></div>
+            <div
+              id="clearButton"
+              part="clear-button"
+              slot="suffix"
+              role="button"
+              on-click="_removeAll"
+              hidden\$="[[!clearButtonVisible]]">
+            </div>
+
             <div id="toggleButton" part="toggle-button" slot="suffix" role="button"></div>
           </vaadin-text-field>
         </div>

--- a/src/multiselect-combo-box-mixin.js
+++ b/src/multiselect-combo-box-mixin.js
@@ -77,6 +77,14 @@ export const MultiselectComboBoxMixin = (base) => class extends base {
         type: Boolean,
         value: false,
         reflectToAttribute: true
+      },
+
+      /**
+       * Set to true to display the clear icon which clears the input.
+       */
+      clearButtonVisible: {
+        type: Boolean,
+        value: false
       }
     };
   }

--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -110,7 +110,8 @@ import './multiselect-combo-box-input.js';
               has-value="[[hasValue]]"
               has-label="[[hasLabel]]"
               theme\$="[[theme]]"
-              disabled="[[disabled]]">
+              disabled="[[disabled]]"
+              clear-button-visible="[[clearButtonVisible]]">
             </multiselect-combo-box-input>
           </vaadin-combo-box-light>
 


### PR DESCRIPTION
To better align with the vaadin component defaults, the `clear-button-visible`
attribute is now also available to the `multiselect-combo-box`. With this update
the component no longer displays the clear icon by default, but instead
it needs to be specified explicitly. This change breaks the default behavior
in favor of aligning better with the current default behavior of the
`vaadin-text-field` and `vaadin-combo-box` components.