### PR TITLE
 backported the `clear-button-visible` attribute

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "multiselect-combo-box",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A multi select combo box web component based on Polymer 2.x and the vaadin-combo-box",
   "main": "multiselect-combo-box.html",
   "license": "Apache-2.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -255,5 +255,38 @@
         </template>
       </demo-snippet>
     </div>
+
+    <div class="vertical-section-container centered">
+      <h3>Multiselect-combo-box with `clear-button-visible`</h3>
+      <demo-snippet>
+        <template>
+
+          <multiselect-combo-box
+            id="clearButtonVisibleDemo"
+            label="Multiselect field with clear-button-visible"
+            placeholder="Add"
+            clear-button-visible>
+          </multiselect-combo-box>
+
+          <script>
+            window.addEventListener('WebComponentsReady', function() {
+              const basicMultiselectComboBox = document.querySelector('#clearButtonVisibleDemo');
+              basicMultiselectComboBox.items = [
+                'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
+                'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
+                'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus',
+                'Sulfur', 'Chlorine', 'Argon', 'Potassium', 'Calcium',
+                'Scandium', 'Titanium', 'Vanadium', 'Chromium', 'Manganese',
+                'Iron', 'Cobalt', 'Nickel', 'Copper', 'Zinc'
+              ];
+              basicMultiselectComboBox.selectedItems = [
+                'Helium',
+                'Lithium'
+              ];
+            });
+          </script>
+        </template>
+      </demo-snippet>
+    </div>
   </body>
 </html>

--- a/demo/material/index.html
+++ b/demo/material/index.html
@@ -284,5 +284,38 @@
         </template>
       </demo-snippet>
     </div>
+
+    <div class="vertical-section-container centered">
+      <h3>Multiselect-combo-box with `clear-button-visible`</h3>
+      <demo-snippet>
+        <template>
+
+          <multiselect-combo-box
+            id="clearButtonVisibleDemo"
+            label="Multiselect field with clear-button-visible"
+            placeholder="Add"
+            clear-button-visible>
+          </multiselect-combo-box>
+
+          <script>
+            window.addEventListener('WebComponentsReady', function() {
+              const basicMultiselectComboBox = document.querySelector('#clearButtonVisibleDemo');
+              basicMultiselectComboBox.items = [
+                'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
+                'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
+                'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus',
+                'Sulfur', 'Chlorine', 'Argon', 'Potassium', 'Calcium',
+                'Scandium', 'Titanium', 'Vanadium', 'Chromium', 'Manganese',
+                'Iron', 'Cobalt', 'Nickel', 'Copper', 'Zinc'
+              ];
+              basicMultiselectComboBox.selectedItems = [
+                'Helium',
+                'Lithium'
+              ];
+            });
+          </script>
+        </template>
+      </demo-snippet>
+    </div>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiselect-combo-box",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A multi select combo box web component based on Polymer 2.x and the vaadin-combo-box",
   "main": "multiselect-combo-box.html",
   "directories": {

--- a/src/multiselect-combo-box-input.html
+++ b/src/multiselect-combo-box-input.html
@@ -34,7 +34,15 @@
         theme$="[[theme]]"
         disabled="[[disabled]]">
 
-        <div id="clearButton" part="clear-button" slot="suffix" role="button" on-click="_removeAll"></div>
+        <div
+          id="clearButton"
+          part="clear-button"
+          slot="suffix"
+          role="button"
+          on-click="_removeAll"
+          hidden$="[[!clearButtonVisible]]">
+        </div>
+
         <div id="toggleButton" part="toggle-button" slot="suffix" role="button"></div>
       </vaadin-text-field>
     </div>

--- a/src/multiselect-combo-box-mixin.html
+++ b/src/multiselect-combo-box-mixin.html
@@ -81,6 +81,14 @@ window.MultiselectComboBoxMixin = (base) => class extends base {
         type: Boolean,
         value: false,
         reflectToAttribute: true
+      },
+
+      /**
+       * Set to true to display the clear icon which clears the input.
+       */
+      clearButtonVisible: {
+        type: Boolean,
+        value: false
       }
     };
   }

--- a/src/multiselect-combo-box.html
+++ b/src/multiselect-combo-box.html
@@ -93,7 +93,8 @@
           has-value="[[hasValue]]"
           has-label="[[hasLabel]]"
           theme$="[[theme]]"
-          disabled="[[disabled]]">
+          disabled="[[disabled]]"
+          clear-button-visible="[[clearButtonVisible]]">
         </multiselect-combo-box-input>
       </vaadin-combo-box-light>
 


### PR DESCRIPTION
To better align with the new defaults for the vaadin components,
the `clear-button-visible` attribute is now also available to the
`multiselect-combo-box`.
With this update the component no longer displays the
clear icon by default, but instead it needs to be specified explicitly.
This change breaks the default behavior in favor of aligning better
with the current default behavior of the `vaadin-text-field` and
the `vaadin-combo-box` components.

ℹ️ This PR backports the same feature that is introduced to the polymer 3 version of this component #41 