### PR TITLE
backported the removed default full width

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -14,6 +14,9 @@
 
     <custom-style>
       <style is="custom-style" include="demo-pages-shared-styles">
+        multiselect-combo-box {
+          width: 100%;
+        }
       </style>
     </custom-style>
   </head>

--- a/demo/material/index.html
+++ b/demo/material/index.html
@@ -14,6 +14,9 @@
 
     <custom-style>
       <style is="custom-style" include="demo-pages-shared-styles">
+        multiselect-combo-box {
+          width: 100%;
+        }
       </style>
     </custom-style>
   </head>

--- a/src/multiselect-combo-box.html
+++ b/src/multiselect-combo-box.html
@@ -13,7 +13,6 @@
     <style>
       :host {
         display: inline-flex;
-        width: 100%;
       }
 
       :host([hidden]) {


### PR DESCRIPTION
Removed default width to better align with the vaadin component set.

ℹ️ This PR backports the same feature that is introduced to the polymer 3 version of this component #46 