### PR TITLE
introduced "join character" property for read only mode

### DIFF
--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -82,7 +82,7 @@ import './multiselect-combo-box-input.js';
           <label part="label">[[label]]</label>
 
           <div part="readonly-container" hidden\$="[[!readonly]]">
-            [[_getReadonlyValue(selectedItems, itemLabelPath, compactMode)]]
+            [[_getReadonlyValue(selectedItems, itemLabelPath, compactMode, readonlyValueSeparator)]]
           </div>
 
           <vaadin-combo-box-light
@@ -231,7 +231,15 @@ import './multiselect-combo-box-input.js';
         /**
          * The `invalid` state error-message.
          */
-        errorMessage: String
+        errorMessage: String,
+
+        /**
+         * The join separator used for the 'display value' when in read-only mode.
+         */
+        readonlyValueSeparator: {
+          type: String,
+          value: ', ' // default value
+        }
       };
     }
 
@@ -257,7 +265,7 @@ import './multiselect-combo-box-input.js';
         this._sortSelectedItems(selectedItems);
       }
 
-      this._setTitle(this._getDisplayValue(selectedItems, this.itemLabelPath));
+      this._setTitle(this._getDisplayValue(selectedItems, this.itemLabelPath, ', '));
 
       this.$.comboBox.render && this.$.comboBox.render();
     }
@@ -330,14 +338,14 @@ import './multiselect-combo-box-input.js';
       }
     }
 
-    _getReadonlyValue(selectedItems, itemLabelPath, compactMode) {
+    _getReadonlyValue(selectedItems, itemLabelPath, compactMode, readonlyValueSeparator) {
       return compactMode ?
         this._getCompactModeDisplayValue(selectedItems) :
-        this._getDisplayValue(selectedItems, itemLabelPath);
+        this._getDisplayValue(selectedItems, itemLabelPath, readonlyValueSeparator);
     }
 
-    _getDisplayValue(selectedItems, itemLabelPath) {
-      return selectedItems.map(item => this._getItemDisplayValue(item, itemLabelPath)).join(', ');
+    _getDisplayValue(selectedItems, itemLabelPath, valueSeparator) {
+      return selectedItems.map(item => this._getItemDisplayValue(item, itemLabelPath)).join(valueSeparator);
     }
 
     get inputElement() {

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -454,21 +454,24 @@
             {id: 3, name: 'item 3'}
           ];
           const itemLabelPath = 'name';
+          const valueSeparator = ';';
 
           // when
-          const result = multiselectComboBox._getDisplayValue(selectedItems, itemLabelPath);
+          const result = multiselectComboBox._getDisplayValue(selectedItems, itemLabelPath, valueSeparator);
 
           // then
-          expect(result).to.be.eql('item 1, item 2, item 3');
+          expect(result).to.be.eql('item 1;item 2;item 3');
         });
 
         it('should return display value', () => {
           // given
           const selectedItems = ['item 11', 'item 22'];
+          const itemLabelPath = undefined;
+          const valueSeparator = ', ';
 
 
           // when
-          const result = multiselectComboBox._getDisplayValue(selectedItems);
+          const result = multiselectComboBox._getDisplayValue(selectedItems, itemLabelPath, valueSeparator);
 
           // then
           expect(result).to.be.eql('item 11, item 22');
@@ -619,12 +622,13 @@
           const compactMode = false;
           const selectedItems = ['item 1', 'item 2'];
           const itemLabelPath = undefined;
+          const readonlyValueSeparator = '; ';
 
           // when
-          const result = multiselectComboBox._getReadonlyValue(selectedItems, itemLabelPath, compactMode);
+          const result = multiselectComboBox._getReadonlyValue(selectedItems, itemLabelPath, compactMode, readonlyValueSeparator);
 
           // then
-          expect(result).to.be.eql('item 1, item 2');
+          expect(result).to.be.eql('item 1; item 2');
         });
 
         it('should get display value of object items when not in compact mode', () => {
@@ -632,12 +636,13 @@
           const compactMode = false;
           const selectedItems = [{label: 'item 1 label'}, {label: 'item 2 label'}];
           const itemLabelPath = 'label';
+          const readonlyValueSeparator = '-';
 
           // when
-          const result = multiselectComboBox._getReadonlyValue(selectedItems, itemLabelPath, compactMode);
+          const result = multiselectComboBox._getReadonlyValue(selectedItems, itemLabelPath, compactMode, readonlyValueSeparator);
 
           // then
-          expect(result).to.be.eql('item 1 label, item 2 label');
+          expect(result).to.be.eql('item 1 label-item 2 label');
         });
 
         it('should get number of selected items when in compact mode and list is empty', () => {


### PR DESCRIPTION
Added the `readonlyValueSeparator` property which specifies the value separator that is used when the component is in read-only mode. The default value of this property is "," 
However with this property it is possible to modify that value (related to https://github.com/gatanaso/multiselect-combo-box-flow/issues/27)