### PR TITLE
cast item display value to string before compare

### DIFF
--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -397,8 +397,8 @@ import './multiselect-combo-box-input.js';
 
     _sortSelectedItems(selectedItems) {
       selectedItems.sort((item1, item2) => {
-        const item1Str = this._getItemDisplayValue(item1, this.itemLabelPath);
-        const item2Str = this._getItemDisplayValue(item2, this.itemLabelPath);
+        const item1Str = String(this._getItemDisplayValue(item1, this.itemLabelPath));
+        const item2Str = String(this._getItemDisplayValue(item2, this.itemLabelPath));
         return item1Str.localeCompare(item2Str);
       });
     }

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -152,6 +152,33 @@
           expect(selectedItems[1]).to.be.eq('item 1');
           expect(selectedItems[2]).to.be.eq('item 3');
         });
+
+        it('should sort non-string object items', () => {
+          // given
+          multiselectComboBox.itemIdPath = 'id';
+          multiselectComboBox.itemValuePath = 'id';
+          multiselectComboBox.itemLabelPath = 'key';
+
+          const selectedItems = [
+            {id: 2, key: 2},
+            {id: 1, key: 1},
+            {id: 3, key: 3}
+          ];
+
+          multiselectComboBox.$.comboBox.render = sinon.stub();
+          multiselectComboBox.$.comboBox._setTitle = sinon.stub();
+
+          multiselectComboBox.ordered = true;
+
+          // when
+
+          multiselectComboBox._selectedItemsObserver(selectedItems);
+
+          // then
+          expect(selectedItems[0]).to.be.eql({id: 1, key: 1});
+          expect(selectedItems[1]).to.be.eql({id: 2, key: 2});
+          expect(selectedItems[2]).to.be.eql({id: 3, key: 3});
+        });
       });
 
       describe('_dispatchChangeEvent', () => {


### PR DESCRIPTION
- To remedy the issue of 'localeCompare' not being a function, the item display value is cast to a String before the compare is executed.

fixes #55 