### PR TITLE
feature/allow custom values

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -276,8 +276,8 @@
 
           <script>
             window.addEventListener('WebComponentsReady', function() {
-              const basicMultiselectComboBox = document.querySelector('#clearButtonVisibleDemo');
-              basicMultiselectComboBox.items = [
+              const clearButtonVisibleMultiselectComboBox = document.querySelector('#clearButtonVisibleDemo');
+              clearButtonVisibleMultiselectComboBox.items = [
                 'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
                 'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
                 'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus',
@@ -285,7 +285,7 @@
                 'Scandium', 'Titanium', 'Vanadium', 'Chromium', 'Manganese',
                 'Iron', 'Cobalt', 'Nickel', 'Copper', 'Zinc'
               ];
-              basicMultiselectComboBox.selectedItems = [
+              clearButtonVisibleMultiselectComboBox.selectedItems = [
                 'Helium',
                 'Lithium'
               ];
@@ -371,6 +371,42 @@
                 root.querySelector('.symbol').textContent = model.item.symbol;
                 root.querySelector('.index').textContent = model.index;
               };
+            });
+          </script>
+        </template>
+      </demo-snippet>
+    </div>
+
+    <div class="vertical-section-container centered">
+      <h3>Allow custom values</h3>
+      <demo-snippet>
+        <template>
+
+          <multiselect-combo-box
+            id="allowCustomValuesDemo"
+            label="Allows input of custom values"
+            placeholder="Select existing or input custom value"
+            allow-custom-values>
+          </multiselect-combo-box>
+
+          <script>
+            window.addEventListener('WebComponentsReady', function() {
+              const customValuesMultiselectComboBox = document.querySelector('#allowCustomValuesDemo');
+              customValuesMultiselectComboBox.items = [
+                'Hydrogen', 'Helium', 'Lithium', 'Beryllium'
+              ];
+              customValuesMultiselectComboBox.selectedItems = [
+                'Helium',
+                'Lithium'
+              ];
+
+              // handle the `custom-values-set` event
+              customValuesMultiselectComboBox.addEventListener('custom-values-set', function(event) {
+                customValuesMultiselectComboBox.items.push(event.detail);
+                const selectedItemsUpdate = customValuesMultiselectComboBox.selectedItems.slice(0);
+                selectedItemsUpdate.push(event.detail);
+                customValuesMultiselectComboBox.selectedItems = selectedItemsUpdate;
+              });
             });
           </script>
         </template>

--- a/demo/material/index.html
+++ b/demo/material/index.html
@@ -306,8 +306,8 @@
 
           <script>
             window.addEventListener('WebComponentsReady', function() {
-              const basicMultiselectComboBox = document.querySelector('#clearButtonVisibleDemo');
-              basicMultiselectComboBox.items = [
+              const clearButtonVisibleMultiselectComboBox = document.querySelector('#clearButtonVisibleDemo');
+              clearButtonVisibleMultiselectComboBox.items = [
                 'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
                 'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
                 'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus',
@@ -315,7 +315,7 @@
                 'Scandium', 'Titanium', 'Vanadium', 'Chromium', 'Manganese',
                 'Iron', 'Cobalt', 'Nickel', 'Copper', 'Zinc'
               ];
-              basicMultiselectComboBox.selectedItems = [
+              clearButtonVisibleMultiselectComboBox.selectedItems = [
                 'Helium',
                 'Lithium'
               ];
@@ -401,6 +401,42 @@
                 root.querySelector('.symbol').textContent = model.item.symbol;
                 root.querySelector('.index').textContent = model.index;
               };
+            });
+          </script>
+        </template>
+      </demo-snippet>
+    </div>
+
+    <div class="vertical-section-container centered">
+      <h3>Allow custom values</h3>
+      <demo-snippet>
+        <template>
+
+          <multiselect-combo-box
+            id="allowCustomValuesDemo"
+            label="Allows input of custom values"
+            placeholder="Select existing or input custom value"
+            allow-custom-values>
+          </multiselect-combo-box>
+
+          <script>
+            window.addEventListener('WebComponentsReady', function() {
+              const customValuesMultiselectComboBox = document.querySelector('#allowCustomValuesDemo');
+              customValuesMultiselectComboBox.items = [
+                'Hydrogen', 'Helium', 'Lithium', 'Beryllium'
+              ];
+              customValuesMultiselectComboBox.selectedItems = [
+                'Helium',
+                'Lithium'
+              ];
+
+              // handle the `custom-values-set` event
+              customValuesMultiselectComboBox.addEventListener('custom-values-set', function(event) {
+                customValuesMultiselectComboBox.items.push(event.detail);
+                const selectedItemsUpdate = customValuesMultiselectComboBox.selectedItems.slice(0);
+                selectedItemsUpdate.push(event.detail);
+                customValuesMultiselectComboBox.selectedItems = selectedItemsUpdate;
+              });
             });
           </script>
         </template>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/gatanaso/multiselect-combo-box"
   },
   "name": "multiselect-combo-box",
-  "version": "2.4.0-alpha",
+  "version": "2.3.1",
   "main": "multiselect-combo-box.js",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/gatanaso/multiselect-combo-box"
   },
   "name": "multiselect-combo-box",
-  "version": "2.3.1",
+  "version": "2.4.0-alpha",
   "main": "multiselect-combo-box.js",
   "directories": {
     "test": "test"

--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -324,11 +324,12 @@ import './multiselect-combo-box-input.js';
 
     _comboBoxValueChanged(event, selectedItem) {
       const item = selectedItem || this.$.comboBox.selectedItem;
+      if (!item) {
+        return;
+      }
 
       const update = this.selectedItems.slice(0);
-
       const index = this._findIndex(item, this.selectedItems, this.itemIdPath);
-
       if (index !== -1) {
         update.splice(index, 1);
       } else {
@@ -372,9 +373,9 @@ import './multiselect-combo-box-input.js';
     }
 
     _findIndex(item, selectedItems, itemIdPath) {
-      if (itemIdPath && item !== undefined) {
+      if (itemIdPath && item) {
         for (let index = 0; index < selectedItems.length; index++) {
-          if (selectedItems[index][itemIdPath] === item[itemIdPath]) {
+          if (selectedItems[index] && selectedItems[index][itemIdPath] === item[itemIdPath]) {
             return index;
           }
         }
@@ -451,6 +452,12 @@ import './multiselect-combo-box-input.js';
 
       if (this.$.comboBox.opened) {
         this._comboBoxValueChanged(event, event.detail.item);
+
+        // When custom values are allowed, we need to clear the input,
+        // so we don't fire a custom values event
+        if (this.allowCustomValues) {
+          this.$.input.value = null;
+        }
 
         // When using a data provider, i.e. in the flow wrapper,
         // we close the overlay after a selection is made and if

--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -97,7 +97,9 @@ import './multiselect-combo-box-input.js';
             item-value-path="[[itemValuePath]]"
             on-change="_comboBoxValueChanged"
             disabled="[[disabled]]"
-            pageSize="[[pageSize]]">
+            page-size="[[pageSize]]"
+            allow-custom-value="[[allowCustomValues]]"
+            on-custom-value-set="_handleCustomValueSet">
 
             <multiselect-combo-box-input
               id="input"
@@ -201,7 +203,9 @@ import './multiselect-combo-box-input.js';
         },
 
         /**
-         * Number of items fetched at a time from the dataprovider. This property is delegated to the underlying `vaadin-combo-box`.
+         * Number of items fetched at a time from the dataprovider.
+         *
+         * This property is delegated to the underlying `vaadin-combo-box`.
          */
         pageSize: {
           type: Number,
@@ -248,6 +252,17 @@ import './multiselect-combo-box-input.js';
         readonlyValueSeparator: {
           type: String,
           value: ', ' // default value
+        },
+
+        /**
+         * If `true`, the user can input a value that is not present in the items list.
+         * `value` property will be set to the input value in this case.
+         *
+         * This property is delegated to the underlying `vaadin-combo-box`.
+         */
+        allowCustomValues: {
+          type: Boolean,
+          value: false
         },
 
         /**
@@ -328,6 +343,20 @@ import './multiselect-combo-box-input.js';
 
       if (this.validate()) {
         this._dispatchChangeEvent();
+      }
+    }
+
+    _handleCustomValueSet(event) {
+      event.preventDefault();
+      if (event.detail) {
+        this.$.input.value = null; // clear input
+        const customValuesSetEvent = new CustomEvent('custom-values-set', {
+          detail: event.detail,
+          composed: true,
+          cancelable: true,
+          bubbles: true
+        });
+        this.dispatchEvent(customValuesSetEvent);
       }
     }
 

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -337,11 +337,11 @@
         it('should not dispath event if validate returns false', () => {
           // given
           multiselectComboBox.validate = sinon.stub();
-          multiselectComboBox.validate.returns(false);
+          multiselectComboBox.validate.returns(false); // force to be false
           multiselectComboBox._dispatchChangeEvent = sinon.stub();
 
           // when
-          multiselectComboBox._comboBoxValueChanged();
+          multiselectComboBox._comboBoxValueChanged({}, 'test item');
 
           // then
           sinon.assert.notCalled(multiselectComboBox._dispatchChangeEvent);
@@ -371,6 +371,23 @@
 
           sinon.assert.calledOnce(multiselectComboBox.validate);
           sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
+        });
+
+        it('should immediatelly return when item is null', () => {
+          // given
+          const event = {};
+          const selectedItem = undefined;
+          multiselectComboBox.$.comboBox.selectedItem = null;
+
+          multiselectComboBox._findIndex = sinon.stub();
+          multiselectComboBox.validate = sinon.stub();
+
+          // when
+          multiselectComboBox._comboBoxValueChanged(event, selectedItem);
+
+          // then
+          sinon.assert.notCalled(multiselectComboBox._findIndex);
+          sinon.assert.notCalled(multiselectComboBox.validate);
         });
       });
 
@@ -995,6 +1012,52 @@
           sinon.assert.calledOnce(event.stopPropagation);
           sinon.assert.calledWith(multiselectComboBox._comboBoxValueChanged, event, event.detail.item);
           sinon.assert.notCalled(multiselectComboBox.$.comboBox.close);
+        });
+
+        it('should clear input value when "allowCustomValues" is true', () => {
+          // given
+          const event = {
+            stopPropagation: sinon.stub(),
+            detail: {
+              item: 'test item'
+            }
+          };
+          multiselectComboBox._comboBoxValueChanged = sinon.stub();
+          multiselectComboBox.$.comboBox.opened = true;
+
+          multiselectComboBox.allowCustomValues = true;
+
+          // when
+          multiselectComboBox._customOverlaySelectedItemChanged(event);
+
+          // then
+          sinon.assert.calledOnce(event.stopPropagation);
+          sinon.assert.calledWith(multiselectComboBox._comboBoxValueChanged, event, event.detail.item);
+
+          expect(multiselectComboBox.$.input.value).to.be.null;
+        });
+
+        it('should not clear input value when "allowCustomValues" is false', () => {
+          // given
+          const event = {
+            stopPropagation: sinon.stub(),
+            detail: {
+              item: 'test item'
+            }
+          };
+          multiselectComboBox._comboBoxValueChanged = sinon.stub();
+          multiselectComboBox.$.comboBox.opened = true;
+
+          multiselectComboBox.allowCustomValues = false;
+
+          // when
+          multiselectComboBox._customOverlaySelectedItemChanged(event);
+
+          // then
+          sinon.assert.calledOnce(event.stopPropagation);
+          sinon.assert.calledWith(multiselectComboBox._comboBoxValueChanged, event, event.detail.item);
+
+          expect(multiselectComboBox.$.input.value).to.not.be.null;
         });
       });
 

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -1054,6 +1054,44 @@
           });
         });
       });
+
+      describe('_handleCustomValueSet', () => {
+        it('should not dispatch a "custom-values-set" event when detail is null or undefined', () => {
+          // given
+          const event = {
+            detail: null
+          };
+          event.preventDefault = sinon.stub();
+          multiselectComboBox.dispatchEvent = sinon.stub();
+
+          // when
+          multiselectComboBox._handleCustomValueSet(event);
+
+          // then
+          sinon.assert.calledOnce(event.preventDefault);
+          sinon.assert.notCalled(multiselectComboBox.dispatchEvent);
+        });
+
+        it('should dispatch a "custom-values-set" event', (done) => {
+          // given
+          multiselectComboBox.$.input.value = 'custom value';
+          const event = {
+            detail: 'custom value'
+          };
+          event.preventDefault = sinon.stub();
+
+          multiselectComboBox.addEventListener('custom-values-set', function(e) {
+            // then
+            expect(e.detail).to.be.eq('custom value');
+            expect(multiselectComboBox.$.input.value).to.be.null;
+            sinon.assert.calledOnce(event.preventDefault);
+            done();
+          });
+
+          // when
+          multiselectComboBox._handleCustomValueSet(event);
+        });
+      });
     });
   </script>
 </body>

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -8,7 +8,10 @@ module.exports = {
       exclude: [],
       thresholds: {
         global: {
-          statements: 100
+          statements: 100,
+          branches: 100,
+          functions: 100,
+          lines: 100
         }
       }
     },


### PR DESCRIPTION
This PR allows adding custom values to the `multiselect-combo-box` (#5). 

If the `allow-custom-values` flag is set the `multiselect-combo-box` will accept input values and fire a `custom-values-set` event. It is the responsibility of the user to decide what to do with that value as it is not automatically added to the list of items or existing values.