### PR TITLE
removed code to explicitly close overlay

### DIFF
--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -458,14 +458,6 @@ import './multiselect-combo-box-input.js';
         if (this.allowCustomValues) {
           this.$.input.value = null;
         }
-
-        // When using a data provider, i.e. in the flow wrapper,
-        // we close the overlay after a selection is made and if
-        // a filter is present. This is to ensure that the overlay
-        // does not immediatelly re-open with the initial items page
-        if (this._hasDataProvider() && this.$.comboBox.filter) {
-          this.$.comboBox.close();
-        }
       }
     }
 

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -964,56 +964,6 @@
           sinon.assert.notCalled(multiselectComboBox._comboBoxValueChanged);
         });
 
-        it('should close the overlay when opened, if using a data provider and a filter is present', () => {
-          // given
-          const event = {
-            stopPropagation: sinon.stub(),
-            detail: {
-              item: 'test item'
-            }
-          };
-          multiselectComboBox._comboBoxValueChanged = sinon.stub();
-          multiselectComboBox.$.comboBox.opened = true;
-
-          multiselectComboBox.$.comboBox.dataProvider = function dummy() {}; // uses data provider
-
-          multiselectComboBox.$.comboBox.close = sinon.stub();
-          multiselectComboBox.$.comboBox.filter = 'test'; // filter present, close is called
-
-          // when
-          multiselectComboBox._customOverlaySelectedItemChanged(event);
-
-          // then
-          sinon.assert.calledOnce(event.stopPropagation);
-          sinon.assert.calledWith(multiselectComboBox._comboBoxValueChanged, event, event.detail.item);
-          sinon.assert.calledOnce(multiselectComboBox.$.comboBox.close);
-        });
-
-        it('should not close the overlay when opened, using a data provider and filter is not present', () => {
-          // given
-          const event = {
-            stopPropagation: sinon.stub(),
-            detail: {
-              item: 'test item'
-            }
-          };
-          multiselectComboBox._comboBoxValueChanged = sinon.stub();
-          multiselectComboBox.$.comboBox.opened = true;
-
-          multiselectComboBox.$.comboBox.dataProvider = function dummy() {}; // uses data provider
-
-          multiselectComboBox.$.comboBox.close = sinon.stub();
-          multiselectComboBox.$.comboBox.filter = ''; // filter not present, close is not called
-
-          // when
-          multiselectComboBox._customOverlaySelectedItemChanged(event);
-
-          // then
-          sinon.assert.calledOnce(event.stopPropagation);
-          sinon.assert.calledWith(multiselectComboBox._comboBoxValueChanged, event, event.detail.item);
-          sinon.assert.notCalled(multiselectComboBox.$.comboBox.close);
-        });
-
         it('should clear input value when "allowCustomValues" is true', () => {
           // given
           const event = {


### PR DESCRIPTION
- Removed the explicit call to close the overlay when a data provider is used and a filter is present. This caused an issue in the java flow wrapper(https://github.com/gatanaso/multiselect-combo-box-flow/issues/42) that the filter would dissapear when an item is chosen from the dropdown list.