### PR TITLE
fix value being lost when focused

### DIFF
--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -345,6 +345,10 @@ import './multiselect-combo-box-input.js';
       if (this.validate()) {
         this._dispatchChangeEvent();
       }
+
+      // reset the focus index, so a value-change event
+      // is not fired when the overlay is closed
+      this.$.comboBox._focusedIndex = -1;
     }
 
     _handleCustomValueSet(event) {

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -249,6 +249,7 @@
           expect(multiselectComboBox.selectedItems).to.include('item 1');
           expect(multiselectComboBox.selectedItems).to.include('item 3');
           expect(multiselectComboBox.$.comboBox.value).to.be.empty;
+          expect(multiselectComboBox.$.comboBox._focusedIndex).to.be.eq(-1);
           sinon.assert.calledOnce(multiselectComboBox.validate);
           sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
         });
@@ -300,6 +301,7 @@
           expect(multiselectComboBox.selectedItems).to.include({id: 1, label: 'item 1'});
           expect(multiselectComboBox.selectedItems).to.include({id: 3, label: 'item 3'});
           expect(multiselectComboBox.$.comboBox.value).to.be.empty;
+          expect(multiselectComboBox.$.comboBox._focusedIndex).to.be.eq(-1);
           sinon.assert.calledOnce(multiselectComboBox.validate);
           sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
         });
@@ -368,6 +370,7 @@
           expect(multiselectComboBox.selectedItems).to.include('item 2');
 
           expect(multiselectComboBox.$.comboBox.value).to.be.null;
+          expect(multiselectComboBox.$.comboBox._focusedIndex).to.be.eq(-1);
 
           sinon.assert.calledOnce(multiselectComboBox.validate);
           sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);


### PR DESCRIPTION
Updated the value change hanlder to also reset the focused index, in order to prevent closing of the overlay to accidentally fire a value-change event if a filter has an exact match with the overlay items.