### PR TITLE
compact mode value renderer

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -129,6 +129,43 @@
     </div>
 
     <div class="vertical-section-container centered">
+      <h3>Multiselect-combo-box in compact mode with custom compact value renderer</h3>
+      <demo-snippet>
+        <template>
+
+          <multiselect-combo-box
+            id="compactModeRenderer"
+            label="Multiselect field"
+            compact-mode>
+          </multiselect-combo-box>
+
+          <script>
+            window.addEventListener('WebComponentsReady', function() {
+              const compactModeMultiselectComboBox = document.querySelector('#compactModeRenderer');
+
+              // Set the compact mode value renderer
+              compactModeMultiselectComboBox.compactModeValueRenderer = function(items) {
+                const suffix = (items.length === 0 || items.length > 1) ? 'chemical elements' : 'chemical element';
+                return `${items.length} ${suffix}`;
+              };
+
+              compactModeMultiselectComboBox.items = [
+                'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
+                'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
+                'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus'
+              ];
+              compactModeMultiselectComboBox.selectedItems = [
+                'Helium',
+                'Lithium',
+                'Beryllium'
+              ];
+            });
+          </script>
+        </template>
+      </demo-snippet>
+    </div>    
+
+    <div class="vertical-section-container centered">
       <h3>Required multiselect-combo-box</h3>
       <demo-snippet>
         <template>

--- a/demo/material/index.html
+++ b/demo/material/index.html
@@ -159,6 +159,43 @@
     </div>
 
     <div class="vertical-section-container centered">
+      <h3>Multiselect-combo-box in compact mode with custom compact value renderer</h3>
+      <demo-snippet>
+        <template>
+
+          <multiselect-combo-box
+            id="compactModeRenderer"
+            label="Multiselect field"
+            compact-mode>
+          </multiselect-combo-box>
+
+          <script>
+            window.addEventListener('WebComponentsReady', function() {
+              const compactModeMultiselectComboBox = document.querySelector('#compactModeRenderer');
+
+              // Set the compact mode value renderer
+              compactModeMultiselectComboBox.compactModeValueRenderer = function(items) {
+                const suffix = (items.length === 0 || items.length > 1) ? 'chemical elements' : 'chemical element';
+                return `${items.length} ${suffix}`;
+              };
+
+              compactModeMultiselectComboBox.items = [
+                'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
+                'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
+                'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus'
+              ];
+              compactModeMultiselectComboBox.selectedItems = [
+                'Helium',
+                'Lithium',
+                'Beryllium'
+              ];
+            });
+          </script>
+        </template>
+      </demo-snippet>
+    </div>    
+
+    <div class="vertical-section-container centered">
       <h3>Required multiselect-combo-box</h3>
       <demo-snippet>
         <template>

--- a/src/multiselect-combo-box-mixin.js
+++ b/src/multiselect-combo-box-mixin.js
@@ -50,7 +50,7 @@ export const MultiselectComboBoxMixin = (base) => class extends base {
        * Custom function for rendering the display value when in compact mode.
        *
        * This function receives the array of selected items and should return
-       * a string value that will will be used as the display value.
+       * a string value that will be used as the display value.
        */
       compactModeValueRenderer: Function,
 

--- a/src/multiselect-combo-box-mixin.js
+++ b/src/multiselect-combo-box-mixin.js
@@ -47,6 +47,14 @@ export const MultiselectComboBoxMixin = (base) => class extends base {
       },
 
       /**
+       * Custom function for rendering the display value when in compact mode.
+       *
+       * This function receives the array of selected items and should return
+       * a string value that will will be used as the display value.
+       */
+      compactModeValueRenderer: Function,
+
+      /**
        * The item property to be used as the `label` in combo-box.
        */
       itemLabelPath: String,
@@ -102,7 +110,11 @@ export const MultiselectComboBoxMixin = (base) => class extends base {
    * @protected
    */
   _getCompactModeDisplayValue(items) {
-    const suffix = (items.length === 0 || items.length > 1) ? 'values' : 'value';
-    return `${items.length} ${suffix}`;
+    if (this.compactModeValueRenderer && typeof this.compactModeValueRenderer === 'function') {
+      return this.compactModeValueRenderer(items);
+    } else {
+      const suffix = (items.length === 0 || items.length > 1) ? 'values' : 'value';
+      return `${items.length} ${suffix}`;
+    }
   }
 };

--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -109,6 +109,7 @@ import './multiselect-combo-box-input.js';
               item-label-path="[[itemLabelPath]]"
               items="[[selectedItems]]"
               compact-mode="[[compactMode]]"
+              compact-mode-value-renderer="[[compactModeValueRenderer]]"
               on-item-removed="_handleItemRemoved"
               on-remove-all-items="_handleRemoveAllItems"
               has-value="[[hasValue]]"

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -731,6 +731,23 @@
           // then
           expect(result).to.be.eql('2 values');
         });
+
+        it('should get custom display value when in compact and using a compact mode value renderer', () => {
+          // given
+          const compactMode = true;
+          const selectedItems = ['item 1', 'item 2'];
+          const itemLabelPath = undefined;
+
+          multiselectComboBox.compactModeValueRenderer = function(items) {
+            return 'two custom items';
+          };
+
+          // when
+          const result = multiselectComboBox._getReadonlyValue(selectedItems, itemLabelPath, compactMode);
+
+          // then
+          expect(result).to.be.eql('two custom items');
+        });
       });
 
       describe('_getItemDisplayValue', () => {


### PR DESCRIPTION
Added a new property, `compactModeValueRenderer` which is a function used to customize
the display value label when in compact mode. The function has one argument, an array
of the selected items and should return a string label to be used as the component
display label in compact mode.

fixes #59 