### PR TITLE
Added `IronResizableBehavior` to the component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 sudo: false
 dist: xenial
-
 language: node_js
-node_js: 8.11
+node_js: lts/*
+
+cache:
+  directories:
+    - node_modules
 
 addons:
   chrome: stable

--- a/package.json
+++ b/package.json
@@ -48,13 +48,14 @@
     "start": "npm run lint && wct --npm && polymer serve --npm --open"
   },
   "dependencies": {
+    "@polymer/iron-resizable-behavior": "^3.0.1",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-combo-box": "^5.0.9",
-    "@vaadin/vaadin-text-field": "^2.4.8",
-    "@vaadin/vaadin-themable-mixin": "^1.4.4",
     "@vaadin/vaadin-control-state-mixin": "^2.1.3",
     "@vaadin/vaadin-lumo-styles": "^1.5.0",
-    "@vaadin/vaadin-material-styles": "^1.2.3"
+    "@vaadin/vaadin-material-styles": "^1.2.3",
+    "@vaadin/vaadin-text-field": "^2.4.8",
+    "@vaadin/vaadin-themable-mixin": "^1.4.4"
   },
   "devDependencies": {
     "@polymer/iron-demo-helpers": "^3.0.0",

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -1170,6 +1170,49 @@
           sinon.assert.notCalled(multiselectComboBox.$server.initDataConnector);
         });
       });
+
+      describe('_notifyResizeIfNeeded', () => {
+        it('should not dispatch `iron-resize` event on init', () => {
+          // given
+          const multiselectComboBox = fixture('multiselectComboBoxFixture');
+          const spy = sinon.spy();
+
+          // when
+          multiselectComboBox.addEventListener('iron-resize', spy);
+
+          // then
+          expect(spy).to.not.be.called;
+        });
+
+        it('should dispatch `iron-resize` event when height changes due to field being invalid', (done) => {
+          // given
+          multiselectComboBox.notifyResize = sinon.spy();
+
+          multiselectComboBox.addEventListener('iron-resize', (event) => {
+            // then
+            sinon.assert.calledOnce(multiselectComboBox.notifyResize);
+            done();
+          });
+
+          // when
+          multiselectComboBox.errorMessage = 'Error message';
+          multiselectComboBox.invalid = true;
+        });
+
+        it('should dispatch `iron-resize` event when height changes due to label', (done) => {
+          // given
+          multiselectComboBox.notifyResize = sinon.spy();
+
+          multiselectComboBox.addEventListener('iron-resize', (event) => {
+            // then
+            sinon.assert.calledOnce(multiselectComboBox.notifyResize);
+            done();
+          });
+
+          // when
+          multiselectComboBox.label = 'Label';
+        });
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
- Introduced the `IronResizableBehavior` such that the `multiselect-combo-box` can announce to containers when it's height has been changed. This is usually needed when the component is used with layouts/components that need to be aware of such changes i.e. the `vaadin-grid`.

related issue: https://github.com/gatanaso/multiselect-combo-box-flow/issues/53