### PR TITLE
Add an optional select-all button to select all available entries (#63)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -163,7 +163,7 @@
           </script>
         </template>
       </demo-snippet>
-    </div>    
+    </div>
 
     <div class="vertical-section-container centered">
       <h3>Required multiselect-combo-box</h3>
@@ -314,6 +314,39 @@
           <script>
             window.addEventListener('WebComponentsReady', function() {
               const clearButtonVisibleMultiselectComboBox = document.querySelector('#clearButtonVisibleDemo');
+              clearButtonVisibleMultiselectComboBox.items = [
+                'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
+                'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
+                'Sodium', 'Magnesium', 'Aluminum', 'Silicon', 'Phosphorus',
+                'Sulfur', 'Chlorine', 'Argon', 'Potassium', 'Calcium',
+                'Scandium', 'Titanium', 'Vanadium', 'Chromium', 'Manganese',
+                'Iron', 'Cobalt', 'Nickel', 'Copper', 'Zinc'
+              ];
+              clearButtonVisibleMultiselectComboBox.selectedItems = [
+                'Helium',
+                'Lithium'
+              ];
+            });
+          </script>
+        </template>
+      </demo-snippet>
+    </div>
+
+    <div class="vertical-section-container centered">
+      <h3>Multiselect-combo-box with `select-all-button-visible`</h3>
+      <demo-snippet>
+        <template>
+
+          <multiselect-combo-box
+            id="selectAllButtonVisibleDemo"
+            label="Multiselect field with select-all-button-visible"
+            placeholder="Add"
+            select-all-button-visible>
+          </multiselect-combo-box>
+
+          <script>
+            window.addEventListener('WebComponentsReady', function() {
+              const clearButtonVisibleMultiselectComboBox = document.querySelector('#selectAllButtonVisibleDemo');
               clearButtonVisibleMultiselectComboBox.items = [
                 'Hydrogen', 'Helium', 'Lithium', 'Beryllium', 'Boron',
                 'Carbon', 'Nitrogen', 'Oxygen', 'Fluorine', 'Neon',
@@ -485,6 +518,6 @@
           </script>
         </template>
       </demo-snippet>
-    </div>    
+    </div>
   </body>
 </html>

--- a/src/multiselect-combo-box-input.js
+++ b/src/multiselect-combo-box-input.js
@@ -21,6 +21,21 @@ import {MultiselectComboBoxMixin} from './multiselect-combo-box-mixin.js';
 
     static get template() {
       return html`
+        <style>
+          /* [part='select-all-button'] {
+            display: none;
+            cursor: default;
+          }
+
+          [part='select-all-button']::before {
+            content: '+';
+          }
+
+          :host([select-all-button-visible]:not([disabled]):not([readonly])) [part='select-all-button'] {
+            display: block;
+          } */
+        </style>
+
         <div id="tokens" part="tokens" slot="prefix">
           <template is="dom-if" if="[[compactMode]]" restamp="">
             <div part="compact-mode-label">[[_getCompactModeLabel(items, compactModeLabelGenerator, items.*)]]</div>
@@ -47,6 +62,15 @@ import {MultiselectComboBoxMixin} from './multiselect-combo-box-mixin.js';
             compact-mode\$="[[compactMode]]"
             theme\$="[[theme]]"
             disabled="[[disabled]]">
+
+            <div
+              id="selectAllButton"
+              part="select-all-button"
+              slot="suffix"
+              role="button"
+              on-click="_selectAll"
+              hidden\$="[[!selectAllButtonVisible]]">
+            </div>
 
             <div
               id="clearButton"
@@ -98,6 +122,14 @@ import {MultiselectComboBoxMixin} from './multiselect-combo-box-mixin.js';
         detail: {
           item: item
         }
+      }));
+    }
+
+    _selectAll(event) {
+      event.stopPropagation();
+      this.dispatchEvent(new CustomEvent('select-all-items', {
+        composed: true,
+        bubbles: true
       }));
     }
 

--- a/src/multiselect-combo-box-mixin.d.ts
+++ b/src/multiselect-combo-box-mixin.d.ts
@@ -20,6 +20,7 @@ declare interface MultiselectComboBoxMixin<T = unknown> {
   itemIdPath: string;
   theme: Theme;
   disabled?: boolean;
+  selectAllButtonVisible?: boolean;
   clearButtonVisible?: boolean;
 }
 

--- a/src/multiselect-combo-box-mixin.js
+++ b/src/multiselect-combo-box-mixin.js
@@ -88,6 +88,14 @@ export const MultiselectComboBoxMixin = (base) => class extends base {
       },
 
       /**
+       * Set to true to display the select-all icon which selects all items.
+       */
+      selectAllButtonVisible: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
        * Set to true to display the clear icon which clears the input.
        */
       clearButtonVisible: {

--- a/src/multiselect-combo-box.js
+++ b/src/multiselect-combo-box.js
@@ -115,11 +115,13 @@ import './multiselect-combo-box-input.js';
               compact-mode="[[compactMode]]"
               compact-mode-label-generator="[[compactModeLabelGenerator]]"
               on-item-removed="_handleItemRemoved"
+              on-select-all-items="_handleSelectAllItems"
               on-remove-all-items="_handleRemoveAllItems"
               has-value="[[hasValue]]"
               has-label="[[hasLabel]]"
               theme\$="[[theme]]"
               disabled="[[disabled]]"
+              select-all-button-visible="[[selectAllButtonVisible]]"
               clear-button-visible="[[clearButtonVisible]]">
             </multiselect-combo-box-input>
           </vaadin-combo-box-light>
@@ -423,6 +425,13 @@ import './multiselect-combo-box-input.js';
       const update = this.selectedItems.slice(0);
       update.splice(update.indexOf(item), 1);
       this.selectedItems = update;
+      if (this.validate()) {
+        this._dispatchChangeEvent();
+      }
+    }
+
+    _handleSelectAllItems() {
+      this.set('selectedItems', this.$.comboBox.items);
       if (this.validate()) {
         this._dispatchChangeEvent();
       }

--- a/test/multiselect-combo-box-input_test.html
+++ b/test/multiselect-combo-box-input_test.html
@@ -147,6 +147,23 @@
         });
       });
 
+      describe('_selectAll', () => {
+        it('should dispatch "select-all-items" event', (done) => {
+          // given
+          const event = {};
+          event.stopPropagation = sinon.stub();
+
+          multiselectComboBoxInput.addEventListener('select-all-items', (e) => {
+            // then
+            sinon.assert.calledOnce(event.stopPropagation);
+            done();
+          });
+
+          // when
+          multiselectComboBoxInput._selectAll(event);
+        });
+      });
+
       describe('_removeAll', () => {
         it('should dispatch "remove-all-items" event', (done) => {
           // given

--- a/test/multiselect-combo-box_test.html
+++ b/test/multiselect-combo-box_test.html
@@ -597,6 +597,41 @@
         });
       });
 
+      describe('_handleSelectAllItems', () => {
+        it('should handle select of all items and validate state', () => {
+          // given
+          multiselectComboBox.items = ['item 1', 'item 2', 'item 3'];
+          multiselectComboBox.selectedItems = ['item 1'];
+          multiselectComboBox.validate = sinon.stub();
+          multiselectComboBox.validate.returns(true);
+          multiselectComboBox._dispatchChangeEvent = sinon.stub();
+
+          // when
+          multiselectComboBox._handleSelectAllItems();
+
+          // then
+          expect(multiselectComboBox.selectedItems).to.be.eq(multiselectComboBox.items);
+          sinon.assert.calledOnce(multiselectComboBox.validate);
+          sinon.assert.calledOnce(multiselectComboBox._dispatchChangeEvent);
+          expect(multiselectComboBox.$.comboBox._focusedIndex).to.be.eq(-1);
+        });
+
+        it('should not dispath event if validate returns false', () => {
+          // given
+          multiselectComboBox.items = ['item 1'];
+          multiselectComboBox.validate = sinon.stub();
+          multiselectComboBox.validate.returns(false);
+          multiselectComboBox._dispatchChangeEvent = sinon.stub();
+
+          // when
+          multiselectComboBox._handleSelectAllItems();
+
+          // then
+          sinon.assert.notCalled(multiselectComboBox._dispatchChangeEvent);
+          expect(multiselectComboBox.$.comboBox._focusedIndex).to.be.eq(-1);
+        });
+      });
+
       describe('_handleRemoveAllItems', () => {
         it('should handle removal of all items and validate state', () => {
           // given
@@ -1175,7 +1210,7 @@
 
           multiselectComboBox.addEventListener('iron-resize', (event) => {
             // then
-            sinon.assert.calledOnce(multiselectComboBox.notifyResize);
+            sinon.assert.called(multiselectComboBox.notifyResize);
             done();
           });
 

--- a/theme/lumo/multiselect-combo-box-input-styles.js
+++ b/theme/lumo/multiselect-combo-box-input-styles.js
@@ -84,6 +84,10 @@ html`
           content: var(--lumo-icons-cross);
         }
 
+        [part='select-all-button']::before {
+          content: var(--lumo-icons-checkmark);
+        }
+
         [part="clear-button"]::before {
           content: var(--lumo-icons-cross);
         }

--- a/theme/material/multiselect-combo-box-input-styles.js
+++ b/theme/material/multiselect-combo-box-input-styles.js
@@ -136,6 +136,10 @@ html`
           background-color: hsla(214, 41%, 17%, 0.83);
         }
 
+        [part="select-all-button"]::before {
+          content: var(--material-icons-clear);
+        }
+
         [part="clear-button"]::before {
           content: var(--material-icons-clear);
         }


### PR DESCRIPTION
- add a new select-all button next to the clear and toggle button
- use a font-icon specific for both Lumo and Material themes
- update demo page to include a demo of the select-all button
- update tests